### PR TITLE
Textdump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ ps1_assets/*.*
 dbank.bin
 dstream.bin
 vag2wav.bin
+textdump.bin
 *.mpq

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-all: dbank.bin dstream.bin vag2wav.bin
+all: dbank.bin dstream.bin vag2wav.bin textdump.bin
 
 dbank.bin: dbank/dbank.c dbank/dbank.h
 	cc -o $@ $<
@@ -10,5 +10,8 @@ dstream.bin: dstream/dstream.c dstream/dstream.h
 vag2wav.bin: vag2wav/vag2wav.c vag2wav/endian.c
 	cc -o $@ $<
 
+textdump.bin: textdump/textdump.c
+	cc -o $@ $<
+
 clean:
-	rm -f dbank.bin dstream.bin vag2wav.bin
+	rm -f dbank.bin dstream.bin vag2wav.bin textdump.bin

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Usage: vag2wav [vag] [wav]
 - vag: .VAG sound file.
 - wav: .WAV sound file.
 
+### textdump
+Outputs strings from a game text data file as C/C++ quoted and escaped strings to stdout.
+
+Usage: textdump [file]
+
+- file: A game text data file, e.g.,  MAINTXT.ENG and MAINTXT.SWE.
+
 ## Compiling
 A Visual Studio workspace is provided to compile the tools. Works with Visual C++ 5.0 and newer.
 For POSIX-compatable OSes, a Makefile is provided.
@@ -48,3 +55,4 @@ as `diabdat.mpq`, then launch Diablo
 # Credits
 - **dstream** and **dbank** written by GalaXyHaXz
 - **vag2wav** taken from the [psxsdk](https://github.com/ColdSauce/psxsdk)
+- **textdump** written by John Törnblom

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Usage: textdump [file]
 
 - file: A game text data file, e.g.,  MAINTXT.ENG and MAINTXT.SWE.
 
-Note that resulting strings are ISO-8859-14 encoded. Use `iconv` to convert them to your encoding:
+Note that resulting strings are windows-1252 encoded. Use `iconv` to convert them to your encoding:
 ```console
-psx-tools$ ./textdump.bin MAINTXT.ENG | iconv -f ISO-8859-14 > MAINTXT.ENG.txt
+psx-tools$ ./textdump.bin MAINTXT.ENG | iconv -f windows-1252 > MAINTXT.ENG.txt
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Usage: textdump [file]
 
 - file: A game text data file, e.g.,  MAINTXT.ENG and MAINTXT.SWE.
 
+Note that resulting strings are ISO-8859-14 encoded. Use `iconv` to convert them to your encoding:
+```console
+psx-tools$ ./textdump.bin MAINTXT.ENG | iconv -f ISO-8859-14 > MAINTXT.ENG.txt
+```
+
+
 ## Compiling
 A Visual Studio workspace is provided to compile the tools. Works with Visual C++ 5.0 and newer.
 For POSIX-compatable OSes, a Makefile is provided.

--- a/textdump/textdump.c
+++ b/textdump/textdump.c
@@ -136,11 +136,7 @@ main(int argc, char *argv[]) {
     exit(1);
   }
 
-  // there is a binary preemble of the format XX YY 00 00,
-  // Lets just skip that one
-  while(i < size - 4 && !str[i+2] && !str[i+3]) {
-    i += 4;
-  }
+  i = (uint8_t)str[1] << 8 | (uint8_t)str[0];
 
   //Next follows null-terminated (iso-8859-14?) strings
   while(i < size) {

--- a/textdump/textdump.c
+++ b/textdump/textdump.c
@@ -1,0 +1,158 @@
+/*
+Copyright (c) 2020, John Törnblom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <stdint.h>
+
+
+static void
+dump_string(const char* str, size_t maxlen) {
+  size_t i = 0;
+
+  fprintf(stdout, "\"");
+
+  while(i < maxlen) {
+    switch(str[i]) {
+    case '\a':
+      fprintf(stdout, "\\a");
+      break;
+
+    case '\b':
+      fprintf(stdout, "\\b");
+      break;
+
+    case '\e':
+      fprintf(stdout, "\\e");
+      break;
+
+    case '\f':
+      fprintf(stdout, "\\f");
+      break;
+
+    case '\n':
+      fprintf(stdout, "\\n");
+      break;
+
+    case '\r':
+      fprintf(stdout, "\\r");
+      break;
+
+    case '\t':
+      fprintf(stdout, "\\t");
+      break;
+
+    case '\v':
+      fprintf(stdout, "\\v");
+      break;
+
+    case '\\':
+      fprintf(stdout, "\\\\");
+      break;
+
+      /*
+    case '\'':
+      fprintf(stdout, "\\\'");
+      break;
+
+    case '\?':
+      fprintf(stdout, "\\?");
+      break;
+      */
+
+    case '\"':
+      fprintf(stdout, "\\\"");
+      break;
+
+    case '\0':
+      i = maxlen;
+      break;
+
+    default:
+      fprintf(stdout, "%c", str[i]);
+    }
+    i++;
+  }
+
+  fprintf(stdout, "\"\n");
+}
+
+
+int
+main(int argc, char *argv[]) {
+  FILE *fp;
+  size_t size, i;
+  char* str;
+
+  if(argc < 2) {
+    fprintf(stderr, "Usage: textdump [file]\n");
+    return 0;
+  }
+
+  if(!(fp = fopen(argv[1], "rb"))) {
+    fprintf(stderr, "Unable to open %s: %s\n",
+	    argv[1], strerror(errno));
+    exit(1);
+  }
+
+  fseek(fp, 0, SEEK_END);
+  size = ftell(fp);
+  rewind(fp);
+
+  str = malloc(size + 1);
+  fread(str, 1, size, fp);
+  fclose(fp);
+
+  str[size] = '\0';
+
+  i = 0;
+  if(size < 4) {
+    fprintf(stderr, "Unexpected end of file\n");
+    exit(1);
+  }
+
+  // there is a binary preemble of the format XX YY 00 00,
+  // Lets just skip that one
+  while(i < size - 4 && !str[i+2] && !str[i+3]) {
+    i += 4;
+  }
+
+  //Next follows null-terminated (iso-8859-14?) strings
+  while(i < size) {
+    if(str[i]) {
+      dump_string(&str[i], size - i);
+      i += strnlen(&str[i], size - i);
+    } else {
+      i++;
+    }
+  }
+
+  free(str);
+
+  return 0;
+}

--- a/textdump/textdump.c
+++ b/textdump/textdump.c
@@ -136,9 +136,10 @@ main(int argc, char *argv[]) {
     exit(1);
   }
 
+  // first two bytes encodes the header size
   i = (uint8_t)str[1] << 8 | (uint8_t)str[0];
 
-  //Next follows null-terminated (iso-8859-14?) strings
+  // next follows null-terminated (windows-1252?) strings
   while(i < size) {
     if(str[i]) {
       dump_string(&str[i], size - i);


### PR DESCRIPTION
These changes introduce a simple tool to extract strings from PS1 data files that store game text. The string values are not identical to the ones used in devilutionX, but pretty close. In particular, there seems to be differences in the use spaces and "|" in Source/textdat.cpp. However, matching strings using an edit distance is sufficient (I used Levenshtein).