### PR TITLE
More fixes for build_mpq.bat script

### DIFF
--- a/build_mpq.bat
+++ b/build_mpq.bat
@@ -5,7 +5,7 @@
 setlocal enabledelayedexpansion
 
 :: Get the directory of the script
-:: %~dp0 is drive+path of %0
+:: %~dp0 is drive+path of %0 (e.g., C:\psx-tools\)
 set "SCRIPTDIR=%~dp0"
 set "PSXDIR=%SCRIPTDIR%ps1_assets"
 
@@ -21,60 +21,82 @@ pushd "%TEMPDIR%"
 
 :: Iterate through each .dir file in the PSXDIR directory
 for /r "%PSXDIR%" %%d in (*.dir) do (
-    :: %%~nxd is filename+extension of %%d
+    :: %%~nxd is filename+extension of %%d (e.g., stream1.dir)
     set "TMP=%%~nxd"
     mkdir "!TMP!"
 
+    :: %%~dpnd is drive+path+filename of %%d, without extension (e.g., C:\Temp\stream1)
+    set "DIR=%%d"
+    set "BIN=%%~dpnd.bin"
+
     :: Run dstream.exe on the .dir file
-    :: %%~dpnd is drive+path+filename of %%d, without extension
     pushd "!TMP!"
-    "%DSTREAM%" "%%d" "%%~dpnd.bin" > nul
+    "%DSTREAM%" "!DIR!" "!BIN!" > nul
     popd
 
     :: Convert VAG files to WAV
-    :: %%~dnpv is drive+path+filename of %%v, without extension
-    for /r "!TMP!" %%v in (*.VAG) do (
-        "%VAG2WAV%" "%%v" "%%~dpnv.WAV" > nul
+    for %%v in (!TMP!\*.VAG) do (
+        :: %%~dpnv is drive+path+filename of %%v, without extension (e.g., C:\Temp\stream1.dir\E0079)
+        set "VAG=%%v"
+        set "WAV=%%~dpnv.WAV"
+        "%VAG2WAV%" "!VAG!" "!WAV!" > nul
     )
 
     :: (Optional) Handle .BOF to .BNK conversion (commented out in original)
-    rem for /r "%TEMPDIR%\!TMP!" %%b in (*.BOF) do (
-    rem     pushd "!TMP!"
-    rem     "%DBANK%" "%%b" "%%~dpnb.BNK" > nul
-    rem     popd
+    rem pushd "!TMP!"
+    rem for %%b in (*.BOF) do (
+    rem     set "BOF=%%b"
+    rem     set "BNK=%%~dpnb.BNK"
+    rem     "%DBANK%" "!BOF!" "!BNK!" > nul
     rem )
+    rem popd
 )
 
 :: Handle MPQ file creation and stream file copying
 for /d %%s in (stream*) do (
-    :: %%~nxs is filename+extension of %%s
-    :: Even though %%s is a path to a directory,
-    :: the path will still be processed as though it is a path to a file
+    :: %%~nxs is filename+extension of %%s (e.g., stream1.dir)
+    rem Even though %%s is a path to a directory,
+    rem the path will still be processed as though it is a path to a file
     set "STREAM=%%~nxs"
     mkdir "!STREAM!\mpq"
 
     :: Read from the .map file and copy files
-    :: We are reading two tokens from each line in the .map file
-    :: so those values are assigned to %%a and %%b respectively
-    for /f "tokens=1,2" %%a in ('type "%SCRIPTDIR%!STREAM!.map"') do (
-        :: Since %%~pb would expand the relative path using the current directory,
-        :: we use a fake for loop to create variable %%c to get the path relative to !STREAM!\mpq instead
-        for /f "tokens=1 delims=" %%c in ("!STREAM!\mpq\%%b") do mkdir "%%~dpc"
-        copy "%%s\%%a" "!STREAM!\mpq\%%b" > nul
+    rem We are reading two tokens from each line in the .map file
+    rem so those values are assigned to %%a and %%b respectively
+    for /f "tokens=1,2" %%a in ('type "%SCRIPTDIR%%%~ns.map"') do (
+        set "SRC=%%s\%%a"
+
+        :: Convert forward slashes to backslashes
+        set "DST=%%b"
+        set "DST=!STREAM!\mpq\!DST:/=\!"
+
+        :: %%~dpc is drive+path of %%c (e.g, C:\Temp\script1.dir\mpq\sfx\towners\)
+        rem In order to parse drive+path from !DST!,
+        rem we use a fake for loop to create variable %%c
+        for /f "tokens=1 delims=" %%c in ("!DST!") do set "DSTDIR=%%~dpc"
+
+        if not exist "!DSTDIR!" mkdir "!DSTDIR!"
+        copy "!SRC!" "!DST!" > nul
     )
 
+    :: %%~ns is the filename of %%s, without extension (e.g., stream1)
+    set "MPQ=%%~ns.mpq"
+    set "MPQ=%SCRIPTDIR%!MPQ!"
+
     :: Create the MPQ file
-    :: %%~ns is the filename of %%s, without extension
-    set "MPQ=%SCRIPTDIR%%%~ns.mpq"
     smpq -M 1 -C none -c "!MPQ!"
 
     pushd "!STREAM!\mpq"
     for /r %%f in (*) do (
-        :: %%f contains a full path,
-        :: this hack uses %CD% (current directory)
-        :: to convert it to a relative path
+        :: %%f contains a full absolute path
         set FULL=%%f
-        smpq -a -C none "!MPQ!" "!FULL:%CD%\=!"
+
+        :: Use a fake for loop to create variable %%d with the value of !CD! (current directory),
+        rem then use it to convert the full absolute path into a relative path
+        for /f "tokens=1 delims=" %%d in ("!CD!") do set "REL=!FULL:%%d\=!"
+
+        :: Add the file to the MPQ
+        smpq -a -C none "!MPQ!" "!REL!"
     )
     popd
 )


### PR DESCRIPTION
Can't say I'm surprised, but I was so far off with the last PR.

* Prevent `The system cannot find the drive specified` errors due to multiple consecutive `::` comments inside for loops.
  * Use `set` to move some of the more confusing syntax into simple variable assignments, isolating those particular comments.
  * Comments in for loops that still need multiple lines must use `rem`.
* Use `if not exist` to avoid errors from making directories that already exist.
* Because `%CD%` is updated by `pushd` inside a for loop, we need to use delayed expansion with `!CD!` to properly fix the relative paths.

This was nearly tested in its entirety. The only thing I didn't do was install `smpq`. Instead, I used `echo` to print out the `smpq` statements to ensure that the arguments looked okay.