### PR TITLE
build_mpq.sh compatible with macOS bash 3.2 and improve safety

### DIFF
--- a/build_mpq.sh
+++ b/build_mpq.sh
@@ -11,11 +11,11 @@ VAG2WAV=$SCRIPTDIR/vag2wav.bin
 
 
 TEMPDIR=$(mktemp -d)
-#trap "rm -rf $TEMPDIR" EXIT
+trap "rm -rf $TEMPDIR" EXIT
 
 cd $TEMPDIR
 
-for DIR in $PSXDIR/*.dir; do
+for DIR in $PSXDIR/*.DIR; do
     TMP=$(basename $DIR)
     mkdir -p $TMP
 
@@ -30,7 +30,7 @@ for DIR in $PSXDIR/*.dir; do
 #    done
 done
 
-for STREAM in stream*; do
+for STREAM in STREAM*; do
     mkdir -p $STREAM/mpq
     while read -r SRC DST; do
 	mkdir -p $(dirname $STREAM/mpq/$DST)
@@ -38,6 +38,7 @@ for STREAM in stream*; do
     done < $SCRIPTDIR/${STREAM::-4}.map
 
     MPQ=$SCRIPTDIR/${STREAM::-4}.mpq
+    rm -rf $MPQ
     smpq -M 1 -C none -c $MPQ
     (cd $STREAM/mpq; find * -type f -exec smpq -a -C none $MPQ "{}" \;)
 done

--- a/build_mpq.sh
+++ b/build_mpq.sh
@@ -32,7 +32,7 @@ for DIR in "$PSXDIR"/*.DIR; do
     TMP="$(basename "$DIR")"
     mkdir -p "$TMP"
 
-    (cd "$TMP"; "$DSTREAM" "$DIR" "${DIR%.DIR}.bin" > /dev/null)
+    (cd "$TMP"; "$DSTREAM" "$DIR" "${DIR%.DIR}.BIN" > /dev/null)
 
     # Convert extracted VAG audio files to WAV
     for VAG in $TMP/*.VAG; do
@@ -46,14 +46,18 @@ for DIR in "$PSXDIR"/*.DIR; do
 done
 
 # Build MPQ files using mapping definitions
-for STREAM in STREAM*; do
+for STREAM in STREAM?.DIR; do
+    # Convert directory name to lowercase and remove .DIR suffix (bash 3.2 compatible)
+    STREAM_BASE="${STREAM%.DIR}"
+    STREAM_LOWER=$(echo "$STREAM_BASE" | tr '[:upper:]' '[:lower:]')
+
     mkdir -p "$STREAM/mpq"
     while read -r SRC DST; do
 	mkdir -p "$(dirname "$STREAM/mpq/$DST")"
 	cp "$STREAM/$SRC" "$STREAM/mpq/$DST"
-    done < "$SCRIPTDIR/${STREAM%.DIR}.map"
+    done < "$SCRIPTDIR/$STREAM_LOWER.map"
 
-    MPQ="$SCRIPTDIR/${STREAM%.DIR}.mpq"
+    MPQ="$SCRIPTDIR/$STREAM_LOWER.mpq"
     rm -rf "$MPQ"
     smpq -M 1 -C none -c "$MPQ"
     (cd "$STREAM/mpq"; find * -type f -exec smpq -a -C none "$MPQ" "{}" \;)

--- a/build_mpq.sh
+++ b/build_mpq.sh
@@ -1,44 +1,60 @@
 #!/usr/bin/env bash
+#
+# Build MPQ files from PlayStation (PSX) Diablo assets.
+#
+# Required external executables:
+#   - dstream.bin: extract PSX .DIR/.BIN archives
+#   - dbank.bin  : convert .BOF sound banks to .BNK
+#   - vag2wav.bin: convert PSX VAG audio to WAV
+#   - smpq       : create and populate MPQ archives
+#
 
-SCRIPTDIR="$(readlink -f $0)"
+# Resolve the absolute path of this script
+SCRIPTDIR="$(readlink -f "$0")"
 SCRIPTDIR="$(dirname "${SCRIPTDIR}")"
 
-PSXDIR=$SCRIPTDIR/ps1_assets
+# Directory containing original PSX asset files
+PSXDIR="$SCRIPTDIR/ps1_assets"
 
-DSTREAM=$SCRIPTDIR/dstream.bin
-DBANK=$SCRIPTDIR/dbank.bin
-VAG2WAV=$SCRIPTDIR/vag2wav.bin
+# Helper tools used for extracting and converting assets
+DSTREAM="$SCRIPTDIR/dstream.bin"
+DBANK="$SCRIPTDIR/dbank.bin"
+VAG2WAV="$SCRIPTDIR/vag2wav.bin"
 
+# Create a temporary working directory and ensure cleanup on exit
+TEMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEMPDIR"' EXIT
 
-TEMPDIR=$(mktemp -d)
-trap "rm -rf $TEMPDIR" EXIT
+cd "$TEMPDIR"
 
-cd $TEMPDIR
+# Process each PSX .DIR archive
+for DIR in "$PSXDIR"/*.DIR; do
+    TMP="$(basename "$DIR")"
+    mkdir -p "$TMP"
 
-for DIR in $PSXDIR/*.DIR; do
-    TMP=$(basename $DIR)
-    mkdir -p $TMP
+    (cd "$TMP"; "$DSTREAM" "$DIR" "${DIR%.DIR}.bin" > /dev/null)
 
-    (cd $TMP; $DSTREAM $DIR ${DIR::-4}.bin > /dev/null)
-
+    # Convert extracted VAG audio files to WAV
     for VAG in $TMP/*.VAG; do
-	$VAG2WAV $VAG ${VAG::-4}.WAV > /dev/null
+	"$VAG2WAV" "$VAG" "${VAG%.VAG}.WAV" > /dev/null
     done
 
-#    for BOF in $TEMPDIR/$TMP/*.BOF; do
-#	(cd $TMP; $DBANK $BOF ${BOF::-4}.BNK > /dev/null)
-#    done
+    # (Optional) Convert BOF sound banks to BNK format
+    # for BOF in "$TEMPDIR/$TMP"/*.BOF; do
+	# (cd "$TMP"; "$DBANK" "$BOF" "${BOF%.BOF}.BNK" > /dev/null)
+    # done
 done
 
+# Build MPQ files using mapping definitions
 for STREAM in STREAM*; do
-    mkdir -p $STREAM/mpq
+    mkdir -p "$STREAM/mpq"
     while read -r SRC DST; do
-	mkdir -p $(dirname $STREAM/mpq/$DST)
-	cp $STREAM/$SRC $STREAM/mpq/$DST
-    done < $SCRIPTDIR/${STREAM::-4}.map
+	mkdir -p "$(dirname "$STREAM/mpq/$DST")"
+	cp "$STREAM/$SRC" "$STREAM/mpq/$DST"
+    done < "$SCRIPTDIR/${STREAM%.DIR}.map"
 
-    MPQ=$SCRIPTDIR/${STREAM::-4}.mpq
-    rm -rf $MPQ
-    smpq -M 1 -C none -c $MPQ
-    (cd $STREAM/mpq; find * -type f -exec smpq -a -C none $MPQ "{}" \;)
+    MPQ="$SCRIPTDIR/${STREAM%.DIR}.mpq"
+    rm -rf "$MPQ"
+    smpq -M 1 -C none -c "$MPQ"
+    (cd "$STREAM/mpq"; find * -type f -exec smpq -a -C none "$MPQ" "{}" \;)
 done


### PR DESCRIPTION
build_mpq.sh compatible with macOS bash 3.2 and improve safety
- Replace bash 4+ specific substring expansions with portable parameter expansion
- Quote all path and variable expansions to safely handle spaces
- Add concise comments describing each processing step and assumptions
- Clarify required external tools and script behavior