### PR TITLE
  Fix sample clipping in vag2wav ADPCM decoder

### DIFF
--- a/vag2wav/vag2wav.c
+++ b/vag2wav/vag2wav.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 
 #include "endian.c"
 
@@ -18,6 +19,16 @@ double f[5][2] = { { 0.0, 0.0 },
 	{ 122.0 / 64.0, -60.0 / 64.0 } };
 
 double samples[28];
+
+/* Clamp an integer to the int16_t range [-32768, 32767].
+ * The ADPCM prediction filter can produce samples that exceed
+ * the 16-bit range; without clamping, the lower 16 bits would
+ * wrap around, causing severe audio distortion. */
+static inline int16_t av_clip_int16(int a)
+{
+	if((a+0x8000) & ~0xFFFF) return (a>>31) ^ 0x7FFF;
+	else						 return a;
+}
 
 int main( int argc, char *argv[] )
 {
@@ -170,7 +181,7 @@ int main( int argc, char *argv[] )
 			samples[i] = samples[i] + s_1 * f[predict_nr][0] + s_2 * f[predict_nr][1];
 			s_2 = s_1;
 			s_1 = samples[i];
-			d = (int) ( samples[i] + 0.5 );
+            d = av_clip_int16(samples[i] + 0.5);
 			fputc( d & 0xff, pcm );
 			fputc( d >> 8, pcm );
 		}


### PR DESCRIPTION
Clamp decoded samples to the int16_t range using av_clip_int16()to prevent wrap-around distortion when the prediction filter produces out-of-range values.

In fact, clip noise occurred in several VAG files.